### PR TITLE
Add certificate public key hash

### DIFF
--- a/scanner/tlsresults.go
+++ b/scanner/tlsresults.go
@@ -300,7 +300,7 @@ func NewTLSCertHostProcessor(certfile, hostfile, chrfile, scsvfile, httpfile str
 	}
 
 	// Cache for already exported certificates
-	t.certCache = make(map[string]map[string]struct{})
+	t.certCache = make(map[string]map[string]struct{}, 256)
 
 	t.timeDiff = getNtpLocalTimeDiff()
 

--- a/scanner/tlsresults.go
+++ b/scanner/tlsresults.go
@@ -26,7 +26,7 @@ const endPublicKey = "-----END PUBLIC KEY-----"
 var hostCsvHeader = []string{"host", "rtt", "port", "server_name", "synStart", "synEnd", "scanEnd", "protocol", "cipher", "resultString", "verify_err_no", "verify_code", "server_version", "depth", "depth_verbose", "error_data"}
 
 // chrCsvHeader represents the header line of the cert_host_rel.csv file
-var chrCsvHeader = []string{"cert_hash", "pub_key_hash", "host", "port", "server_name", "depth"}
+var chrCsvHeader = []string{"cert_hash", "host", "port", "server_name", "depth", "pub_key_hash"}
 
 // certCsvHeader represents the header line of the certs.csv file
 var certCsvHeader = []string{"cert", "cert_hash"}

--- a/scanner/tlsresults.go
+++ b/scanner/tlsresults.go
@@ -219,7 +219,7 @@ type TLSCertHostProcessor struct {
 	scsvFh       *os.File
 	httpFh       *os.File
 	timeDiff     time.Duration
-	certCache    map[string]bool
+	certCache    map[string]map[string]struct{}
 	cipherSuites map[uint16]string
 	skipErrors   bool
 	cacheFunc    func([]byte) []byte
@@ -300,7 +300,7 @@ func NewTLSCertHostProcessor(certfile, hostfile, chrfile, scsvfile, httpfile str
 	}
 
 	// Cache for already exported certificates
-	t.certCache = make(map[string]bool)
+	t.certCache = make(map[string]map[string]struct{})
 
 	t.timeDiff = getNtpLocalTimeDiff()
 

--- a/scanner/tlsresults.go
+++ b/scanner/tlsresults.go
@@ -26,7 +26,7 @@ const endPublicKey = "-----END PUBLIC KEY-----"
 var hostCsvHeader = []string{"host", "rtt", "port", "server_name", "synStart", "synEnd", "scanEnd", "protocol", "cipher", "resultString", "verify_err_no", "verify_code", "server_version", "depth", "depth_verbose", "error_data"}
 
 // chrCsvHeader represents the header line of the cert_host_rel.csv file
-var chrCsvHeader = []string{"cert_hash", "host", "port", "server_name", "depth"}
+var chrCsvHeader = []string{"cert_hash", "pub_key_hash", "host", "port", "server_name", "depth"}
 
 // certCsvHeader represents the header line of the certs.csv file
 var certCsvHeader = []string{"cert", "cert_hash"}

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/csv"
 	"encoding/hex"
-	"encoding/pem"
 	"errors"
 	"net"
 	"os"

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -444,8 +444,8 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 				var sha1PubKey string
 				if err != nil {
 					log.WithFields(log.Fields{
-						"ip": ip,
-						"cert_hash": sha256Hex,
+						"cert_hash":   sha256Hex,
+						"ip":          ip,
 						"server_name": h.domain,
 					}).Error("Could not parse public key")
 					sha1PubKey = ""

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -439,24 +439,8 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 				}
 
 				// Write to certificate-host relation CSV file
-				// [cert_hash, pub_key_hash, host, port, depth]
-				publicKeyDer, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
-				var sha2PubKey string
-				if err != nil {
-					log.WithFields(log.Fields{
-						"cert_hash":   sha256Hex,
-						"ip":          ip,
-						"server_name": h.domain,
-					}).Error("Could not parse public key")
-					sha2PubKey = ""
-				} else {
-					publicKeyBlock := pem.Block{
-						Type:  "PUBLIC KEY",
-						Bytes: publicKeyDer,
-					}
-
-					sha2PubKey = hex.EncodeToString(getSHA256(pem.EncodeToMemory(&publicKeyBlock)))
-				}
+				// [cert_hash, host, port, depth, pub_key_hash]
+				sha2PubKey := hex.EncodeToString(getSHA256(cert.RawSubjectPublicKeyInfo))
 
 				if ok := chrCsv.Write([]string{sha256Hex, ip, port, h.domain, strconv.Itoa(i), sha2PubKey}); ok != nil {
 					log.WithFields(log.Fields{

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -441,24 +441,24 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 				// Write to certificate-host relation CSV file
 				// [cert_hash, pub_key_hash, host, port, depth]
 				publicKeyDer, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
-				var sha1PubKey string
+				var sha2PubKey string
 				if err != nil {
 					log.WithFields(log.Fields{
 						"cert_hash":   sha256Hex,
 						"ip":          ip,
 						"server_name": h.domain,
 					}).Error("Could not parse public key")
-					sha1PubKey = ""
+					sha2PubKey = ""
 				} else {
 					publicKeyBlock := pem.Block{
 						Type:  "PUBLIC KEY",
 						Bytes: publicKeyDer,
 					}
 
-					sha1PubKey = hex.EncodeToString(getSHA1(pem.EncodeToMemory(&publicKeyBlock)))
+					sha2PubKey = hex.EncodeToString(getSHA256(pem.EncodeToMemory(&publicKeyBlock)))
 				}
 
-				if ok := chrCsv.Write([]string{sha256Hex, sha1PubKey, ip, port, h.domain, strconv.Itoa(i)}); ok != nil {
+				if ok := chrCsv.Write([]string{sha256Hex, ip, port, h.domain, strconv.Itoa(i), sha2PubKey}); ok != nil {
 					log.WithFields(log.Fields{
 						"file": chrFh.Name(),
 					}).Error("Error writing to host-certificate-relationship file")

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -290,7 +290,7 @@ func (h *CertHostTLSTarget) AddResult(address string, res *ScanResult) {
 }
 
 // Dump writes the retrieved certificates to a csv file
-func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File, timediff time.Duration, certCache map[string]bool, cipherSuites map[uint16]string, skipErrors bool, cacheFunc func([]byte) []byte) error {
+func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File, timediff time.Duration, certCache map[string]map[string]struct{}, cipherSuites map[uint16]string, skipErrors bool, cacheFunc func([]byte) []byte) error {
 
 	// Create CSV file instances
 	hostCsv := csv.NewWriter(hostFh)
@@ -405,11 +405,16 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 				sha256Hex := hex.EncodeToString(getSHA256(cert.Raw))
 
 				if cacheFunc != nil {
-					cacheBytes := cacheFunc(cert.Raw)
-
 					// Check if certificate was already written out before
 					// Use byte string as map key to save memory (slices can not be used as map key)
-					if !certCache[string(cacheBytes)] {
+					cacheBytes := string(cacheFunc(cert.Raw))
+
+					_, ok := certCache[cacheBytes[:1]]
+
+					if !ok {
+						certCache[cacheBytes[:1]] = make(map[string]struct{})
+					}
+					if _, ok := certCache[cacheBytes[:1]][cacheBytes]; !ok {
 						// Write row in cert CSV file
 						// [cert, cert_hash]
 						certString := opensslFormat(base64.StdEncoding.EncodeToString(cert.Raw), beginCertificate, endCertificate)
@@ -418,7 +423,7 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 								"file": certFh.Name(),
 							}).Error("Error writing to certificate file")
 						} else {
-							certCache[string(cacheBytes)] = true
+							certCache[cacheBytes[:1]][cacheBytes] = struct{}{}
 						}
 					}
 				} else {

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -439,9 +439,9 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 
 				// Write to certificate-host relation CSV file
 				// [cert_hash, host, port, depth, pub_key_hash]
-				sha2PubKey := hex.EncodeToString(getSHA256(cert.RawSubjectPublicKeyInfo))
+				sha256SPKI := hex.EncodeToString(getSHA256(cert.RawSubjectPublicKeyInfo))
 
-				if ok := chrCsv.Write([]string{sha256Hex, ip, port, h.domain, strconv.Itoa(i), sha2PubKey}); ok != nil {
+				if ok := chrCsv.Write([]string{sha256Hex, ip, port, h.domain, strconv.Itoa(i), sha256SPKI}); ok != nil {
 					log.WithFields(log.Fields{
 						"file": chrFh.Name(),
 					}).Error("Error writing to host-certificate-relationship file")

--- a/scanner/tlstarget.go
+++ b/scanner/tlstarget.go
@@ -414,7 +414,7 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 					if !ok {
 						certCache[cacheBytes[:1]] = make(map[string]struct{})
 					}
-					if _, ok := certCache[cacheBytes[:1]][cacheBytes]; !ok {
+					if _, ok := certCache[cacheBytes[:1]][cacheBytes[1:]]; !ok {
 						// Write row in cert CSV file
 						// [cert, cert_hash]
 						certString := opensslFormat(base64.StdEncoding.EncodeToString(cert.Raw), beginCertificate, endCertificate)
@@ -423,7 +423,7 @@ func (h *CertHostTLSTarget) Dump(hostFh, certFh, chrFh, scsvFh, httpFh *os.File,
 								"file": certFh.Name(),
 							}).Error("Error writing to certificate file")
 						} else {
-							certCache[cacheBytes[:1]][cacheBytes] = struct{}{}
+							certCache[cacheBytes[:1]][cacheBytes[1:]] = struct{}{}
 						}
 					}
 				} else {


### PR DESCRIPTION
Bases on [PR7](https://github.com/tumi8/goscanner/pull/7)

- adds the public key of the certificate to the host certificate relation file in order to no load all certificates to compare public keys.
- maybe an option to enable/disable should be added